### PR TITLE
Support remote Qwen inputs via JSON endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,111 @@
 # Memory-Garden
+
+## Recent updates
+
+- Switched the `/generate-stories/` endpoint to call Hugging Face's hosted
+  `Qwen/Qwen2.5-VL-7B-Instruct` model, so the FastAPI service no longer needs to
+  download or serve the weights locally.
+- Documented how mobile apps can POST multiple images to the endpoint and what
+  to expect in the JSON response, including deployment and HTTPS guidance.
+- Added an alternate `/generate-stories/from-remote/` workflow for base64 or
+  URL-sourced images, matching Hugging Face's API guidance for Qwen VL inputs.
+
+## Testing
+
+To verify that the application source files have no syntax errors you can run:
+
+```bash
+python -m compileall app
+```
+
+This command asks Python to byte-compile every module under `app/`. It does **not** start the FastAPI server or download the Qwen model; it simply emits `.pyc` files under `app/__pycache__` if the code parses successfully.
+
+## Hugging Face Inference API configuration
+
+Story generation now calls the public Inference API for [`Qwen/Qwen2.5-VL-7B-Instruct`](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct). Set a Hugging Face access token in the `HUGGING_FACE_API_TOKEN` environment variable before starting the FastAPI server. You can also override the model id using `HUGGING_FACE_MODEL_ID` if you would like to target a different hosted checkpoint listed on the Hugging Face model page:
+
+```bash
+export HUGGING_FACE_API_TOKEN="hf_your_token_here"
+# Optional: override the default model id of Qwen/Qwen2.5-VL-7B-Instruct
+export HUGGING_FACE_MODEL_ID="Qwen/Qwen2.5-VL-7B-Instruct"
+uvicorn app.main:app --reload
+```
+
+The `/generate-stories/` endpoint accepts multiple image uploads and forwards each photo and the storytelling prompt to Hugging Face for inference.
+
+## Integrating with a mobile app
+
+Yes—FastAPI exposes standard HTTP endpoints that mobile clients can call just like any other REST or JSON API. To integrate the `/generate-stories/` route into a native iOS or Android application:
+
+1. Deploy the FastAPI service (for example with `uvicorn app.main:app --host 0.0.0.0 --port 8000`).
+2. From the mobile app, send a `POST` request to `https://<your-backend-host>/generate-stories/` with a `multipart/form-data` body that contains one or more image files under the form field name `images`.
+3. Parse the JSON response. Each entry under the `results` array contains the original filename and the generated story text.
+
+Because mobile apps typically talk to HTTPS backends, make sure the deployment includes TLS termination (for example behind an API gateway or managed load balancer). You can also add authentication or request signing at the FastAPI layer if the mobile integration requires it.
+
+## Manually testing with real photos
+
+To try the `/generate-stories/` endpoint yourself with actual image files:
+
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   If you want helper utilities that mirror Hugging Face's Qwen VL API helpers
+   for base64, URL, or video inputs you can also install the optional toolkit:
+
+   ```bash
+   # Linux users can install the faster decord extras.
+   pip install "qwen-vl-utils[decord]==0.0.8"
+   
+   # On non-Linux systems fall back to the torchvision-backed build.
+   pip install qwen-vl-utils==0.0.8
+   ```
+2. **Export your Hugging Face credentials** so the service can call the hosted model:
+   ```bash
+   export HUGGING_FACE_API_TOKEN="hf_your_token_here"
+   # Optional: point to a different hosted checkpoint
+   export HUGGING_FACE_MODEL_ID="Qwen/Qwen2.5-VL-7B-Instruct"
+   ```
+3. **Start the FastAPI server** (this example runs it locally on port 8000):
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+4. **Send a test request with your photos.** In a separate terminal, use `curl` (or a REST client such as Postman or Thunder Client) to upload one or more image files. Replace the sample filenames with the paths to your pictures:
+   ```bash
+   curl -X POST "http://127.0.0.1:8000/generate-stories/" \
+        -H "Authorization: Bearer $HUGGING_FACE_API_TOKEN" \
+        -F "images=@/path/to/first_photo.jpg" \
+        -F "images=@/path/to/second_photo.png" \
+        -F "prompt=Write a gentle story about seasonal celebrations"
+   ```
+   The endpoint returns JSON that lists each uploaded filename and the generated story text. If the Hugging Face model is still loading you may receive a `202 Accepted` response—retry the request after a few seconds.
+5. **Review the output** in the terminal or your REST client. You can share the JSON back with the mobile team or plug it into your UI to validate the storytelling experience.
+
+If you deploy the service remotely, adjust the URL in step 4 to match the public HTTPS address and ensure that the `HUGGING_FACE_API_TOKEN` environment variable is set on the server.
+
+## Calling the API with base64 or URLs
+
+The Hugging Face Inference API for Qwen VL also accepts interleaved text and
+vision inputs via base64 payloads or remote URLs. To mirror that flexibility the
+FastAPI service exposes `/generate-stories/from-remote/`, which accepts JSON
+payloads describing each image source:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/generate-stories/from-remote/" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "prompt": "Gently narrate the family moment in these pictures.",
+           "sources": [
+             {"type": "url", "value": "https://example.com/family-photo.jpg"},
+             {"type": "base64", "value": "<base64-encoded-image>"}
+           ]
+         }'
+```
+
+The response mirrors the multipart endpoint with a `results` array. When you
+need to generate the base64 strings yourself, the `qwen-vl-utils` package listed
+above provides convenience methods for turning local files, URLs, or even video
+frames into the JSON format Hugging Face documents on the
+[Qwen/Qwen2.5-VL-7B-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct)
+model card.

--- a/app/main.py
+++ b/app/main.py
@@ -1,22 +1,30 @@
-from fastapi import FastAPI, File, UploadFile
-from fastapi.responses import JSONResponse
-from typing import List
-from transformers import AutoModelForVision2Seq, AutoTokenizer, AutoProcessor
-import torch
-from PIL import Image
-import tempfile
+import base64
+import binascii
 import os
+from io import BytesIO
+from typing import Any, Dict, List, Literal, Optional
+from urllib.parse import urlparse
+
+import requests
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from PIL import Image, UnidentifiedImageError
 
 app = FastAPI()
 
-qwen_model_id = "Qwen/Qwen2.5-VL-7B-Instruct"
-qwen_model = AutoModelForVision2Seq.from_pretrained(
-    qwen_model_id,
-    dtype=torch.float16,
-    device_map="auto"
-)
-qwen_tokenizer = AutoTokenizer.from_pretrained(qwen_model_id)
-qwen_processor = AutoProcessor.from_pretrained(qwen_model_id)
+DEFAULT_QWEN_MODEL_ID = "Qwen/Qwen2.5-VL-7B-Instruct"
+# The model card lists the public Inference API endpoint and identifier:
+# https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct
+
+
+def _resolve_model_id() -> str:
+    """Return the configured Hugging Face model identifier."""
+
+    model_id = os.getenv("HUGGING_FACE_MODEL_ID", DEFAULT_QWEN_MODEL_ID).strip()
+    if not model_id:
+        raise RuntimeError("HUGGING_FACE_MODEL_ID is set but empty. Provide a valid Hugging Face model id.")
+    return model_id
 
 short_prompt = """Write a 120–180 word micro‑story inspired by this photo for an older adult and their family. Describe the photo honestly, write the story to evoke gentle reminiscence and well‑being. Use warm, simple language, 2–3 sensory details, and avoid object lists. Use tentative phrasing for uncertain facts. Emphasize connection and small rituals."""
 long_prompt = """
@@ -46,48 +54,172 @@ Examples of style knobs you can add:
 - Cultural touch: include respectful, non‑stereotyped details only if clearly present.
 
 """
-def generate_story_qwen(image_path, prompt=short_prompt): # use short_prompt by default
-    image = Image.open(image_path).convert("RGB")
-    messages = [
-        {"role": "user", "content": [
-            {"type": "image"},
-            {"type": "text", "text": prompt}
-        ]}
-    ]
-    text_prompt = qwen_processor.apply_chat_template(
-        messages,
-        tokenize=False,
-        add_generation_prompt=True
+
+
+def _extract_text_from_response(payload: Any) -> Optional[str]:
+    """Return the first text completion found in a Hugging Face response payload."""
+
+    if isinstance(payload, dict):
+        if "choices" in payload and isinstance(payload["choices"], list):
+            for choice in payload["choices"]:
+                message = choice.get("message") if isinstance(choice, dict) else None
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, list):
+                        for item in content:
+                            if isinstance(item, dict) and item.get("type") == "text":
+                                text = item.get("text")
+                                if isinstance(text, str):
+                                    return text
+                    text = message.get("content")
+                    if isinstance(text, str):
+                        return text
+                text = choice.get("text") if isinstance(choice, dict) else None
+                if isinstance(text, str):
+                    return text
+        generated_text = payload.get("generated_text")
+        if isinstance(generated_text, str):
+            return generated_text
+    if isinstance(payload, list):
+        for item in payload:
+            text = _extract_text_from_response(item)
+            if text:
+                return text
+    return None
+
+
+def generate_story_qwen(image_bytes: bytes, prompt: str = short_prompt) -> str:
+    """Generate a story for a single image.
+
+    Args:
+        image_bytes: Raw bytes of the uploaded image.
+        prompt: Prompt text used when querying the model.
+
+    Returns:
+        The generated story as a string.
+    """
+
+    try:
+        # Validate the bytes represent an image; discard the converted copy afterwards.
+        Image.open(BytesIO(image_bytes)).convert("RGB")
+    except (UnidentifiedImageError, OSError) as exc:
+        raise ValueError("Uploaded file is not a valid image.") from exc
+
+    hf_token = os.getenv("HUGGING_FACE_API_TOKEN")
+    if not hf_token:
+        raise RuntimeError(
+            "Missing HUGGING_FACE_API_TOKEN environment variable required for Hugging Face Inference API access."
+        )
+
+    image_base64 = base64.b64encode(image_bytes).decode("utf-8")
+    payload: Dict[str, Any] = {
+        "inputs": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image_base64},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+        },
+        "parameters": {"max_new_tokens": 320},
+    }
+
+    headers = {
+        "Authorization": f"Bearer {hf_token}",
+        "Content-Type": "application/json",
+    }
+
+    hf_api_url = f"https://api-inference.huggingface.co/models/{_resolve_model_id()}"
+
+    try:
+        response = requests.post(hf_api_url, headers=headers, json=payload, timeout=60)
+    except requests.RequestException as exc:
+        raise RuntimeError("Failed to reach Hugging Face Inference API.") from exc
+
+    if response.status_code in {202, 503}:
+        raise RuntimeError("Model is loading on Hugging Face; please retry in a few moments.")
+
+    if response.status_code >= 400:
+        raise RuntimeError(f"Hugging Face API error ({response.status_code}): {response.text}")
+
+    try:
+        response_payload: Any = response.json()
+    except ValueError as exc:
+        raise RuntimeError("Invalid JSON response from Hugging Face API.") from exc
+
+    text = _extract_text_from_response(response_payload)
+    if not text:
+        raise RuntimeError("Unable to parse generated story from Hugging Face response.")
+
+    return text.strip()
+
+
+class RemoteVisionInput(BaseModel):
+    """Vision input provided via base64 string or URL."""
+
+    type: Literal["base64", "url"] = Field(
+        ..., description="How the model input should be interpreted (base64 data or remote URL)."
     )
-    inputs = qwen_processor(text=[text_prompt], images=[image], return_tensors="pt").to("cuda")
-    output_ids = qwen_model.generate(**inputs, max_new_tokens=300)
-    generated_text = qwen_tokenizer.decode(
-        output_ids[0][inputs["input_ids"].shape[1]:],
-        skip_special_tokens=True
+    value: str = Field(..., description="The base64 payload or URL to the image resource.")
+
+
+class RemoteStoryRequest(BaseModel):
+    """Request payload for generating stories from non-upload sources."""
+
+    sources: List[RemoteVisionInput] = Field(
+        ..., description="List of base64 strings or URLs that point to the images to narrate."
     )
-    return generated_text.strip()
+    prompt: Optional[str] = Field(
+        default=None,
+        description="Optional custom prompt to send to the Hugging Face model.",
+    )
+
+
+def _load_bytes_from_remote_source(source: RemoteVisionInput) -> bytes:
+    """Decode a RemoteVisionInput into image bytes."""
+
+    if source.type == "base64":
+        try:
+            return base64.b64decode(source.value, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError("Invalid base64 image payload.") from exc
+
+    # URL path
+    parsed = urlparse(source.value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Image URL is not valid. Provide an absolute HTTP(S) URL.")
+
+    try:
+        response = requests.get(source.value, timeout=30)
+    except requests.RequestException as exc:
+        raise RuntimeError("Failed to download image from URL.") from exc
+
+    if response.status_code >= 400:
+        raise RuntimeError(f"Image download failed with status {response.status_code}.")
+
+    return response.content
 
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
 
 @app.post("/generate-stories/")
-async def generate_stories(images: List[UploadFile] = File(...)):
+async def generate_stories(images: List[UploadFile] = File(...), prompt: Optional[str] = Form(None)):
     results = []
+    prompt_text = prompt.strip() if isinstance(prompt, str) and prompt.strip() else short_prompt
     for image_file in images:
-        # Save image temporarily
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as tmp:
-            contents = await image_file.read()
-            tmp.write(contents)
-            tmp_path = tmp.name
-
+        contents = await image_file.read()
         try:
-            story = generate_story_qwen(tmp_path)
+            if not contents:
+                raise ValueError("Uploaded file is empty.")
+            story = generate_story_qwen(contents, prompt=prompt_text)
         except Exception as e:
             story = f"Error processing image: {str(e)}"
         finally:
-            # Clean up temp file
-            os.remove(tmp_path)
+            await image_file.close()
 
         results.append({
             "filename": image_file.filename,
@@ -95,3 +227,26 @@ async def generate_stories(images: List[UploadFile] = File(...)):
         })
 
     return JSONResponse(content={"results": results})
+
+
+@app.post("/generate-stories/from-remote/")
+async def generate_stories_from_remote(request: RemoteStoryRequest):
+    """Generate stories for images referenced by base64 payloads or URLs."""
+
+    results = []
+    prompt_text = request.prompt.strip() if request.prompt else short_prompt
+
+    for index, source in enumerate(request.sources, start=1):
+        label = source.value if source.type == "url" else f"base64_{index}"
+        try:
+            image_bytes = _load_bytes_from_remote_source(source)
+            if not image_bytes:
+                raise ValueError("No data received for remote image.")
+            story = generate_story_qwen(image_bytes, prompt=prompt_text)
+        except Exception as exc:
+            story = f"Error processing image: {exc}"
+
+        results.append({"source": label, "story": story})
+
+    return JSONResponse(content={"results": results})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+pillow
+python-multipart
+requests


### PR DESCRIPTION
## Summary
- add a JSON-powered `/generate-stories/from-remote/` endpoint so base64 and URL inputs can reach the hosted Qwen model
- reuse the existing inference flow with new helpers that validate remote payloads and optional prompt overrides
- document the new workflow plus the optional `qwen-vl-utils` toolkit for preparing Hugging Face compatible requests

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e3cb704cf883249843b96db377ea9a